### PR TITLE
Server: Send bots to welcome cam and not allow players to leave it too soon

### DIFF
--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -653,7 +653,7 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 	{
 		// don't let him spawn as soon as he enters the server
 		// give enough time to plugins to send the player to spectator mode
-		pPlayer->m_flNextAttack = 1.0;
+		pPlayer->m_flNextAttack = 0.2;
 
 		pPlayer->StartWelcomeCam();
 		return;

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -649,8 +649,12 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 	CBaseEntity	*pWeaponEntity = NULL;
 
 	// Start welcome cam for new players
-	if (!pPlayer->m_bPutInServer && !pPlayer->m_bIsBot && mp_welcomecam.value != 0)
+	if (!pPlayer->m_bPutInServer && mp_welcomecam.value != 0)
 	{
+		// don't let him spawn as soon as he enters the server
+		// give enough time to plugins to send the player to spectator mode
+		pPlayer->m_flNextAttack = 1.0;
+
 		pPlayer->StartWelcomeCam();
 		return;
 	}

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1942,7 +1942,14 @@ void CBasePlayer::PreThink(void)
 	// Welcome cam buttons handling
 	if (m_bInWelcomeCam)
 	{
-		if (m_afButtonPressed & IN_ATTACK)
+		if (m_flNextAttack > 0)
+			return;
+
+		if (m_bIsBot) 
+		{
+			StopWelcomeCam();
+		} 
+		else if (m_afButtonPressed & IN_ATTACK )
 		{
 			StopWelcomeCam();
 		}

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -332,7 +332,7 @@ public:
 	BOOL m_bPutInServer;	// we set it after PutInServer finished
 	BOOL m_bIsBot;			// we set it at PutInServer start
 	BOOL IsConnected() { return m_bConnected; }
-	void Disconnect() { m_bConnected = FALSE; m_bPutInServer = FALSE; m_bIsBot = FALSE; }
+	void Disconnect() { m_bConnected = FALSE; m_bPutInServer = FALSE; m_bIsBot = FALSE; m_bInWelcomeCam = FALSE; }
 
 	Vector m_vecLastViewAngles;
 


### PR DESCRIPTION
Not allow players to leave welcome cam mode too soon (Useful for send players to spec when they join).